### PR TITLE
Update README to reference DirectWebSdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,16 +60,16 @@ To allow your web app to retrieve keys:
 1. Install the package
    `npm i @toruslabs/torus-direct-web-sdk`
 
-2. Serve [service worker](public/sw.js) from `baseUrl` where baseUrl is the one passed while instantiating `TorusSdk` for specific login (example http://localhost:3000/serviceworker/). If you're already using a sw, pls ensure to port over the fetch override from [our service worker](public/sw.js)
+2. Serve [service worker](public/sw.js) from `baseUrl` where baseUrl is the one passed while instantiating `DirectWebSdk` for specific login (example http://localhost:3000/serviceworker/). If you're already using a sw, pls ensure to port over the fetch override from [our service worker](public/sw.js)
 
-3. For browsers where service workers are not supported or if you wish to not use service workers, create and serve [redirect page](public/redirect.html) from `baseUrl/redirect` where baseUrl is the one passed while instantiating `TorusSdk` for specific login ( example http://localhost:3000/serviceworker/)
+3. For browsers where service workers are not supported or if you wish to not use service workers, create and serve [redirect page](public/redirect.html) from `baseUrl/redirect` where baseUrl is the one passed while instantiating `DirectWebSdk` for specific login ( example http://localhost:3000/serviceworker/)
 
-4. At verifier's interface (where you obtain client id), please use `baseUrl/redirect` (eg: http://localhost:3000/serviceworker/redirect) as the redirect_uri where baseUrl is the one passed while instantiating `TorusSdk`
+4. At verifier's interface (where you obtain client id), please use `baseUrl/redirect` (eg: http://localhost:3000/serviceworker/redirect) as the redirect_uri where baseUrl is the one passed while instantiating `DirectWebSdk`
 
 5. Instantiate the package with your own specific client-id
 
 ```js
-const torus = new TorusSdk({
+const torus = new DirectWebSdk({
   baseUrl: "http://localhost:3000/serviceworker/",
   GOOGLE_CLIENT_ID: "MY CLIENT ID GOOGLE",
   proxyContractAddress: "0x4023d2a0D330bF11426B12C6144Cfb96B7fa6183", // details for test net


### PR DESCRIPTION
Library at:


```js
<script src="https://cdn.jsdelivr.net/npm/@toruslabs/torus-direct-web-sdk"></script>
```

exports `DirectWebSdk`, not `TorusSdk`