### PR TITLE
Integrate with loglevel-sentry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2690,6 +2690,63 @@
         "fastq": "^1.6.0"
       }
     },
+    "@sentry/browser": {
+      "version": "5.30.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-5.30.0.tgz",
+      "integrity": "sha512-rOb58ZNVJWh1VuMuBG1mL9r54nZqKeaIlwSlvzJfc89vyfd7n6tQ1UXMN383QBz/MS5H5z44Hy5eE+7pCrYAfw==",
+      "requires": {
+        "@sentry/core": "5.30.0",
+        "@sentry/types": "5.30.0",
+        "@sentry/utils": "5.30.0",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/core": {
+      "version": "5.30.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.30.0.tgz",
+      "integrity": "sha512-TmfrII8w1PQZSZgPpUESqjB+jC6MvZJZdLtE/0hZ+SrnKhW3x5WlYLvTXZpcWePYBku7rl2wn1RZu6uT0qCTeg==",
+      "requires": {
+        "@sentry/hub": "5.30.0",
+        "@sentry/minimal": "5.30.0",
+        "@sentry/types": "5.30.0",
+        "@sentry/utils": "5.30.0",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/hub": {
+      "version": "5.30.0",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.30.0.tgz",
+      "integrity": "sha512-2tYrGnzb1gKz2EkMDQcfLrDTvmGcQPuWxLnJKXJvYTQDGLlEvi2tWz1VIHjunmOvJrB5aIQLhm+dcMRwFZDCqQ==",
+      "requires": {
+        "@sentry/types": "5.30.0",
+        "@sentry/utils": "5.30.0",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/minimal": {
+      "version": "5.30.0",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.30.0.tgz",
+      "integrity": "sha512-BwWb/owZKtkDX+Sc4zCSTNcvZUq7YcH3uAVlmh/gtR9rmUvbzAA3ewLuB3myi4wWRAMEtny6+J/FN/x+2wn9Xw==",
+      "requires": {
+        "@sentry/hub": "5.30.0",
+        "@sentry/types": "5.30.0",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/types": {
+      "version": "5.30.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.30.0.tgz",
+      "integrity": "sha512-R8xOqlSTZ+htqrfteCWU5Nk0CDN5ApUTvrlvBuiH1DyP6czDZ4ktbZB0hAgBlVcK0U+qpD3ag3Tqqpa5Q67rPw=="
+    },
+    "@sentry/utils": {
+      "version": "5.30.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.30.0.tgz",
+      "integrity": "sha512-zaYmoH0NWWtvnJjC9/CBseXMtKHm/tm40sz3YfJRxeQjyzRqNQPgivpd9R/oDJCYj999mzdW382p/qi2ypjLww==",
+      "requires": {
+        "@sentry/types": "5.30.0",
+        "tslib": "^1.9.3"
+      }
+    },
     "@toruslabs/eccrypto": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/@toruslabs/eccrypto/-/eccrypto-1.1.5.tgz",
@@ -2717,6 +2774,15 @@
       "integrity": "sha512-Bg9AE3lPaPCv9OQAFusQlCE5TxxJCuT3R9ilGMhDiOfWQdtdW0f+cfzoRSQGA1I/lq0V217MNvWeJNLejLdsSA==",
       "requires": {
         "deepmerge": "^4.2.2"
+      }
+    },
+    "@toruslabs/loglevel-sentry": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@toruslabs/loglevel-sentry/-/loglevel-sentry-1.0.1.tgz",
+      "integrity": "sha512-dwkDe3fl3acgZtn8q/JeUZml4lR15iQlpUQQLK48tzdkN9HYBqEDNWGZL/t/oLSa+ufj0nwny4Vnwf5AN4m7IA==",
+      "requires": {
+        "@sentry/browser": "^5.30.0",
+        "loglevel": "^1.7.1"
       }
     },
     "@toruslabs/torus.js": {
@@ -9788,8 +9854,7 @@
     "tslib": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
-      "dev": true
+      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
     },
     "tsutils": {
       "version": "3.19.1",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@chaitanyapotti/register-service-worker": "^1.7.3",
     "@toruslabs/fetch-node-details": "^2.3.4",
     "@toruslabs/http-helpers": "^1.3.5",
+    "@toruslabs/loglevel-sentry": "^1.0.1",
     "@toruslabs/torus.js": "^2.2.13",
     "broadcast-channel": "^3.3.0",
     "deepmerge": "^4.2.2",

--- a/src/handlers/interfaces.ts
+++ b/src/handlers/interfaces.ts
@@ -62,6 +62,7 @@ export interface DirectWebSDKArgs {
   network?: TORUS_NETWORK_TYPE;
   proxyContractAddress?: string;
   enableLogging?: boolean;
+  enableErrorReporter?: boolean;
   redirectToOpener?: boolean;
   redirectPathName?: string;
   apiKey?: string;

--- a/src/login.ts
+++ b/src/login.ts
@@ -21,7 +21,7 @@ import {
 import { registerServiceWorker } from "./registerServiceWorker";
 import { AGGREGATE_VERIFIER, CONTRACT_MAP, ETHEREUM_NETWORK, LOGIN_TYPE, TORUS_NETWORK } from "./utils/enums";
 import { handleRedirectParameters, padUrlString } from "./utils/helpers";
-import log from "./utils/loglevel";
+import log, { sentry } from "./utils/loglevel";
 
 class DirectWebSDK {
   isInitialized: boolean;
@@ -41,6 +41,7 @@ class DirectWebSDK {
     network = TORUS_NETWORK.MAINNET,
     proxyContractAddress = CONTRACT_MAP[TORUS_NETWORK.MAINNET],
     enableLogging = false,
+    enableErrorReporter = false,
     redirectToOpener = false,
     redirectPathName = "redirect",
     apiKey = "torus-default",
@@ -64,8 +65,11 @@ class DirectWebSDK {
     const ethNetwork = network === TORUS_NETWORK.TESTNET ? ETHEREUM_NETWORK.ROPSTEN : network;
     this.nodeDetailManager = new NodeDetailManager({ network: ethNetwork, proxyAddress: proxyContractAddress || CONTRACT_MAP[network] });
     this.nodeDetailManager.getNodeDetails();
+
     if (enableLogging) log.enableAll();
     else log.disableAll();
+
+    sentry.setEnabled(enableErrorReporter);
   }
 
   async init({ skipSw = false }: InitParams = {}): Promise<void> {

--- a/src/utils/loglevel.ts
+++ b/src/utils/loglevel.ts
@@ -1,3 +1,12 @@
+import Sentry from "@toruslabs/loglevel-sentry";
 import loglevel from "loglevel";
 
-export default loglevel.getLogger("torus-direct-web-sdk");
+const logger = loglevel.getLogger("torus-direct-web-sdk");
+
+export const sentry = new Sentry({
+  dsn: "https://c806006328f941cc8e4da01bf9d3009d@o503538.ingest.sentry.io/5588794",
+  sampleRate: 1,
+});
+sentry.install(logger);
+
+export default logger;

--- a/src/utils/loglevel.ts
+++ b/src/utils/loglevel.ts
@@ -5,7 +5,8 @@ const logger = loglevel.getLogger("torus-direct-web-sdk");
 
 export const sentry = new Sentry({
   dsn: "https://c806006328f941cc8e4da01bf9d3009d@o503538.ingest.sentry.io/5588794",
-  sampleRate: 1,
+  release: process.env.SENTRY_RELEASE,
+  sampleRate: 0.5,
 });
 sentry.install(logger);
 

--- a/types/src/handlers/interfaces.d.ts
+++ b/types/src/handlers/interfaces.d.ts
@@ -59,6 +59,7 @@ export interface DirectWebSDKArgs {
     network?: TORUS_NETWORK_TYPE;
     proxyContractAddress?: string;
     enableLogging?: boolean;
+    enableErrorReporter?: boolean;
     redirectToOpener?: boolean;
     redirectPathName?: string;
     apiKey?: string;

--- a/types/src/login.d.ts
+++ b/types/src/login.d.ts
@@ -10,7 +10,7 @@ declare class DirectWebSDK {
     };
     torus: Torus;
     nodeDetailManager: NodeDetailManager;
-    constructor({ baseUrl, network, proxyContractAddress, enableLogging, redirectToOpener, redirectPathName, apiKey, }: DirectWebSDKArgs);
+    constructor({ baseUrl, network, proxyContractAddress, enableLogging, enableErrorReporter, redirectToOpener, redirectPathName, apiKey, }: DirectWebSDKArgs);
     init({ skipSw }?: InitParams): Promise<void>;
     private handleRedirectCheck;
     triggerLogin({ verifier, typeOfLogin, clientId, jwtParams, hash, queryParameters }: SubVerifierDetails): Promise<TorusLoginResponse>;

--- a/types/src/utils/loglevel.d.ts
+++ b/types/src/utils/loglevel.d.ts
@@ -1,3 +1,5 @@
+import Sentry from "@toruslabs/loglevel-sentry";
 import loglevel from "loglevel";
-declare const _default: loglevel.Logger;
-export default _default;
+declare const logger: loglevel.Logger;
+export declare const sentry: Sentry;
+export default logger;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,12 +2,13 @@
 const path = require("path");
 const ESLintPlugin = require("eslint-webpack-plugin");
 
+const webpack = require("webpack");
 const pkg = require("./package.json");
 
 const pkgName = "directWebSdk";
 const libraryName = pkgName.charAt(0).toUpperCase() + pkgName.slice(1);
 
-const packagesToInclude = ["broadcast-channel", "@toruslabs/torus.js", "@toruslabs/fetch-node-details","@toruslabs/loglevel-sentry"];
+const packagesToInclude = ["broadcast-channel", "@toruslabs/torus.js", "@toruslabs/fetch-node-details", "@toruslabs/loglevel-sentry"];
 
 const { NODE_ENV = "production" } = process.env;
 
@@ -32,6 +33,11 @@ const baseConfig = {
   module: {
     rules: [],
   },
+  plugins: [
+    new webpack.DefinePlugin({
+      "process.env.SENTRY_RELEASE": JSON.stringify(`torus-direct-web-sdk@v${pkg.version}`),
+    }),
+  ],
 };
 
 const optimization = {
@@ -87,6 +93,7 @@ const cjsConfig = {
   },
   externals: [...Object.keys(pkg.dependencies), /^(@babel\/runtime)/i],
   plugins: [
+    ...baseConfig.plugins,
     new ESLintPlugin({
       extensions: ".ts",
     }),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,7 +7,7 @@ const pkg = require("./package.json");
 const pkgName = "directWebSdk";
 const libraryName = pkgName.charAt(0).toUpperCase() + pkgName.slice(1);
 
-const packagesToInclude = ["broadcast-channel", "@toruslabs/torus.js", "@toruslabs/fetch-node-details"];
+const packagesToInclude = ["broadcast-channel", "@toruslabs/torus.js", "@toruslabs/fetch-node-details","@toruslabs/loglevel-sentry"];
 
 const { NODE_ENV = "production" } = process.env;
 


### PR DESCRIPTION
This PR use [@toruslabs/loglevel-sentry](https://www.npmjs.com/package/@toruslabs/loglevel-sentry) to hook Sentry calls into existing loglevel invocations.

To trace what functions/arguments caused errors, use `log.info`/`log.trace`/`log.debug`.

An example errors:
<img width="844" alt="Screen Shot 2021-01-18 at 12 17 09" src="https://user-images.githubusercontent.com/25026967/104875137-21f39280-5987-11eb-98a8-cf2d36b06143.png">
