### PR TITLE
Feat/skip fetch node details

### DIFF
--- a/src/handlers/AbstractLoginHandler.ts
+++ b/src/handlers/AbstractLoginHandler.ts
@@ -30,7 +30,7 @@ abstract class AbstractLoginHandler implements ILoginHandler {
     return encodeURIComponent(
       window.btoa(
         JSON.stringify({
-          ...this.customState,
+          ...(this.customState || {}),
           instanceId: this.nonce,
           verifier: this.verifier,
           typeOfLogin: this.typeOfLogin,
@@ -46,7 +46,9 @@ abstract class AbstractLoginHandler implements ILoginHandler {
 
   handleLoginWindow(params: { locationReplaceOnRedirect?: boolean; popupFeatures?: string }): Promise<LoginWindowResponse> {
     const verifierWindow = new PopupHandler({ url: this.finalURL, features: params.popupFeatures });
-    if (this.uxMode === UX_MODE.POPUP) {
+    if (this.uxMode === UX_MODE.REDIRECT) {
+      verifierWindow.redirect(params.locationReplaceOnRedirect);
+    } else {
       return new Promise<LoginWindowResponse>((resolve, reject) => {
         let bc: BroadcastChannel;
         const handleData = async (ev: { error: string; data: PopupResponse }) => {
@@ -102,9 +104,6 @@ abstract class AbstractLoginHandler implements ILoginHandler {
           reject(new Error("user closed popup"));
         });
       });
-    }
-    if (this.uxMode === UX_MODE.REDIRECT) {
-      verifierWindow.redirect(params.locationReplaceOnRedirect);
     }
     return null;
   }

--- a/src/handlers/interfaces.ts
+++ b/src/handlers/interfaces.ts
@@ -110,6 +110,7 @@ export interface DirectWebSDKArgs {
   redirectParamsStorageMethod?: REDIRECT_PARAMS_STORAGE_METHOD_TYPE;
   locationReplaceOnRedirect?: boolean;
   popupFeatures?: string;
+  skipFetchingNodeDetails?: boolean;
 }
 
 export interface InitParams {
@@ -234,10 +235,10 @@ export interface CreateHandlerParams {
   clientId: string;
   verifier: string;
   redirect_uri: string;
-  uxMode: UX_MODE_TYPE;
+  uxMode?: UX_MODE_TYPE;
   redirectToOpener?: boolean;
   jwtParams?: Auth0ClientOptions;
-  customState: TorusGenericObject;
+  customState?: TorusGenericObject;
   registerOnly?: boolean;
 }
 

--- a/src/login.ts
+++ b/src/login.ts
@@ -67,6 +67,7 @@ class DirectWebSDK {
     redirectParamsStorageMethod = REDIRECT_PARAMS_STORAGE_METHOD.SESSION_STORAGE,
     locationReplaceOnRedirect = false,
     popupFeatures,
+    skipFetchingNodeDetails = false,
   }: DirectWebSDKArgs) {
     this.isInitialized = false;
     const baseUri = new URL(baseUrl);
@@ -90,7 +91,7 @@ class DirectWebSDK {
     this.torus = torus;
     const ethNetwork = network === TORUS_NETWORK.TESTNET ? ETHEREUM_NETWORK.ROPSTEN : network;
     this.nodeDetailManager = new NodeDetailManager({ network: ethNetwork, proxyAddress: proxyContractAddress || CONTRACT_MAP[network] });
-    this.nodeDetailManager.getNodeDetails();
+    if (!skipFetchingNodeDetails) this.nodeDetailManager.getNodeDetails();
     if (enableLogging) log.enableAll();
     else log.disableAll();
   }

--- a/types/src/handlers/interfaces.d.ts
+++ b/types/src/handlers/interfaces.d.ts
@@ -98,6 +98,7 @@ export interface DirectWebSDKArgs {
     redirectParamsStorageMethod?: REDIRECT_PARAMS_STORAGE_METHOD_TYPE;
     locationReplaceOnRedirect?: boolean;
     popupFeatures?: string;
+    skipFetchingNodeDetails?: boolean;
 }
 export interface InitParams {
     skipSw?: boolean;

--- a/types/src/handlers/interfaces.d.ts
+++ b/types/src/handlers/interfaces.d.ts
@@ -214,10 +214,10 @@ export interface CreateHandlerParams {
     clientId: string;
     verifier: string;
     redirect_uri: string;
-    uxMode: UX_MODE_TYPE;
+    uxMode?: UX_MODE_TYPE;
     redirectToOpener?: boolean;
     jwtParams?: Auth0ClientOptions;
-    customState: TorusGenericObject;
+    customState?: TorusGenericObject;
     registerOnly?: boolean;
 }
 export interface AggregateLoginParams {

--- a/types/src/login.d.ts
+++ b/types/src/login.d.ts
@@ -15,7 +15,7 @@ declare class DirectWebSDK {
     };
     torus: Torus;
     nodeDetailManager: NodeDetailManager;
-    constructor({ baseUrl, network, proxyContractAddress, enableLogging, redirectToOpener, redirectPathName, apiKey, uxMode, redirectParamsStorageMethod, locationReplaceOnRedirect, popupFeatures, }: DirectWebSDKArgs);
+    constructor({ baseUrl, network, proxyContractAddress, enableLogging, redirectToOpener, redirectPathName, apiKey, uxMode, redirectParamsStorageMethod, locationReplaceOnRedirect, popupFeatures, skipFetchingNodeDetails, }: DirectWebSDKArgs);
     init({ skipSw, skipInit, skipPrefetch }?: InitParams): Promise<void>;
     private handlePrefetchRedirectUri;
     triggerLogin(args: SubVerifierDetails & {


### PR DESCRIPTION
The following changes have been made in this release:
- Allow skipping of fetch node details
- Revert some backward incompatible changes for internal createHandlerFn