### PR TITLE
Feat/ mock login handler

### DIFF
--- a/src/handlers/HandlerFactory.ts
+++ b/src/handlers/HandlerFactory.ts
@@ -4,6 +4,7 @@ import FacebookHandler from "./FacebookHandler";
 import GoogleHandler from "./GoogleHandler";
 import { CreateHandlerParams, ILoginHandler } from "./interfaces";
 import JwtHandler from "./JwtHandler";
+import MockLoginHandler from "./MockLoginHandler";
 import PasswordlessHandler from "./PasswordlessHandler";
 import RedditHandler from "./RedditHandler";
 import TwitchHandler from "./TwitchHandler";
@@ -23,7 +24,7 @@ const createHandler = ({
   if (!verifier || !typeOfLogin || !clientId) {
     throw new Error("Invalid params");
   }
-  const { domain, login_hint } = jwtParams || {};
+  const { domain, login_hint, id_token } = jwtParams || {};
   switch (typeOfLogin) {
     case LOGIN.GOOGLE:
       return new GoogleHandler(clientId, verifier, redirect_uri, typeOfLogin, uxMode, redirectToOpener, jwtParams, customState);
@@ -47,6 +48,9 @@ const createHandler = ({
     case LOGIN.EMAIL_PASSWORD:
     case LOGIN.JWT:
       if (!domain) throw new Error("Invalid params");
+      if (id_token) {
+        return new MockLoginHandler(clientId, verifier, redirect_uri, typeOfLogin, uxMode, redirectToOpener, jwtParams, customState);
+      }
       return new JwtHandler(clientId, verifier, redirect_uri, typeOfLogin, uxMode, redirectToOpener, jwtParams, customState);
     case LOGIN.WEBAUTHN:
       return new WebAuthnHandler(clientId, verifier, redirect_uri, typeOfLogin, uxMode, redirectToOpener, jwtParams, customState, registerOnly);

--- a/src/handlers/MockLoginHandler.ts
+++ b/src/handlers/MockLoginHandler.ts
@@ -1,0 +1,96 @@
+import deepmerge from "deepmerge";
+import jwtDecode from "jwt-decode";
+import log from "loglevel";
+
+import { LOGIN_TYPE, UX_MODE, UX_MODE_TYPE } from "../utils/enums";
+import { constructURL, getVerifierId, padUrlString } from "../utils/helpers";
+import { get } from "../utils/httpHelpers";
+import PopupHandler from "../utils/PopupHandler";
+import AbstractLoginHandler from "./AbstractLoginHandler";
+import { Auth0ClientOptions, Auth0UserInfo, LoginWindowResponse, TorusGenericObject, TorusVerifierResponse } from "./interfaces";
+
+export default class CustomJwtHandler extends AbstractLoginHandler {
+  constructor(
+    readonly clientId: string,
+    readonly verifier: string,
+    readonly redirect_uri: string,
+    readonly typeOfLogin: LOGIN_TYPE,
+    readonly uxMode: UX_MODE_TYPE,
+    readonly redirectToOpener?: boolean,
+    readonly jwtParams?: Auth0ClientOptions,
+    readonly customState?: TorusGenericObject
+  ) {
+    super(clientId, verifier, redirect_uri, typeOfLogin, uxMode, redirectToOpener, jwtParams, customState);
+    this.setFinalUrl();
+  }
+
+  setFinalUrl(): void {
+    const clonedParams = JSON.parse(JSON.stringify(this.jwtParams));
+    delete clonedParams.domain;
+    const finalJwtParams = deepmerge(
+      {
+        state: this.state,
+        client_id: this.clientId,
+        nonce: this.nonce,
+      },
+      clonedParams
+    );
+
+    this.finalURL = new URL(constructURL({ baseURL: this.redirect_uri, query: null, hash: finalJwtParams }));
+  }
+
+  async getUserInfo(params: LoginWindowResponse): Promise<TorusVerifierResponse> {
+    const { idToken, accessToken } = params;
+    const { domain, verifierIdField, isVerifierIdCaseSensitive, user_info_route = "userinfo" } = this.jwtParams;
+    if (accessToken) {
+      try {
+        const domainUrl = new URL(domain);
+        const userInfo = await get<Auth0UserInfo>(`${padUrlString(domainUrl)}${user_info_route}`, {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+          },
+        });
+        const { picture, name, email } = userInfo;
+        return {
+          email,
+          name,
+          profileImage: picture,
+          verifierId: getVerifierId(userInfo, this.typeOfLogin, verifierIdField, isVerifierIdCaseSensitive),
+          verifier: this.verifier,
+          typeOfLogin: this.typeOfLogin,
+        };
+      } catch (error) {
+        // ignore
+        log.warn(error, "Unable to get userinfo from endpoint");
+      }
+    }
+    if (idToken) {
+      const decodedToken = jwtDecode<Auth0UserInfo>(idToken);
+      const { name, email, picture } = decodedToken;
+      return {
+        profileImage: picture,
+        name,
+        email,
+        verifierId: getVerifierId(decodedToken, this.typeOfLogin, verifierIdField, isVerifierIdCaseSensitive),
+        verifier: this.verifier,
+        typeOfLogin: this.typeOfLogin,
+      };
+    }
+    throw new Error("Access/id token not available");
+  }
+
+  handleLoginWindow(params: { locationReplaceOnRedirect?: boolean; popupFeatures?: string }): Promise<LoginWindowResponse> {
+    const { id_token: idToken, access_token: accessToken } = this.jwtParams;
+    const verifierWindow = new PopupHandler({ url: this.finalURL, features: params.popupFeatures });
+    if (this.uxMode === UX_MODE.REDIRECT) {
+      verifierWindow.redirect(params.locationReplaceOnRedirect);
+    } else {
+      return Promise.resolve({
+        state: {},
+        idToken,
+        accessToken,
+      });
+    }
+    return null;
+  }
+}

--- a/src/handlers/interfaces.ts
+++ b/src/handlers/interfaces.ts
@@ -365,6 +365,10 @@ export interface Auth0ClientOptions extends BaseLoginOptions {
    * @defaultValue true
    */
   isVerifierIdCaseSensitive?: boolean;
+
+  id_token?: string;
+
+  access_token?: string;
 }
 
 export interface SubVerifierDetails {
@@ -376,6 +380,7 @@ export interface SubVerifierDetails {
   queryParameters?: TorusGenericObject;
   customState?: TorusGenericObject;
 }
+
 export interface CreateHandlerParams {
   typeOfLogin: LOGIN_TYPE;
   clientId: string;

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -186,3 +186,19 @@ export function getPopupFeatures(): string {
 }
 
 export const isFirefox = (): boolean => window?.navigator?.userAgent.toLowerCase().indexOf("firefox") > -1 || false;
+
+export function constructURL(params: { baseURL: string; query?: Record<string, unknown>; hash?: Record<string, unknown> }): string {
+  const { baseURL, query, hash } = params;
+
+  const url = new URL(baseURL);
+  if (query) {
+    Object.keys(query).forEach((key) => {
+      url.searchParams.append(key, query[key] as string);
+    });
+  }
+  if (hash) {
+    const h = new URL(constructURL({ baseURL, query: hash })).searchParams.toString();
+    url.hash = h;
+  }
+  return url.toString();
+}

--- a/types/src/handlers/MockLoginHandler.d.ts
+++ b/types/src/handlers/MockLoginHandler.d.ts
@@ -1,0 +1,20 @@
+import { LOGIN_TYPE, UX_MODE_TYPE } from "../utils/enums";
+import AbstractLoginHandler from "./AbstractLoginHandler";
+import { Auth0ClientOptions, LoginWindowResponse, TorusGenericObject, TorusVerifierResponse } from "./interfaces";
+export default class CustomJwtHandler extends AbstractLoginHandler {
+    readonly clientId: string;
+    readonly verifier: string;
+    readonly redirect_uri: string;
+    readonly typeOfLogin: LOGIN_TYPE;
+    readonly uxMode: UX_MODE_TYPE;
+    readonly redirectToOpener?: boolean;
+    readonly jwtParams?: Auth0ClientOptions;
+    readonly customState?: TorusGenericObject;
+    constructor(clientId: string, verifier: string, redirect_uri: string, typeOfLogin: LOGIN_TYPE, uxMode: UX_MODE_TYPE, redirectToOpener?: boolean, jwtParams?: Auth0ClientOptions, customState?: TorusGenericObject);
+    setFinalUrl(): void;
+    getUserInfo(params: LoginWindowResponse): Promise<TorusVerifierResponse>;
+    handleLoginWindow(params: {
+        locationReplaceOnRedirect?: boolean;
+        popupFeatures?: string;
+    }): Promise<LoginWindowResponse>;
+}

--- a/types/src/handlers/interfaces.d.ts
+++ b/types/src/handlers/interfaces.d.ts
@@ -335,6 +335,8 @@ export interface Auth0ClientOptions extends BaseLoginOptions {
      * @defaultValue true
      */
     isVerifierIdCaseSensitive?: boolean;
+    id_token?: string;
+    access_token?: string;
 }
 export interface SubVerifierDetails {
     typeOfLogin: LOGIN_TYPE;

--- a/types/src/utils/helpers.d.ts
+++ b/types/src/utils/helpers.d.ts
@@ -38,4 +38,9 @@ export declare function clearLoginDetailsStorage(storageMethod: REDIRECT_PARAMS_
 export declare function clearOrphanedLoginDetails(storageMethod: REDIRECT_PARAMS_STORAGE_METHOD_TYPE): void;
 export declare function getPopupFeatures(): string;
 export declare const isFirefox: () => boolean;
+export declare function constructURL(params: {
+    baseURL: string;
+    query?: Record<string, unknown>;
+    hash?: Record<string, unknown>;
+}): string;
 export {};


### PR DESCRIPTION
- Can pass jwt token directly in triggerLogin functions, which will return privKey directly in case of popup mode and will redirect to `redirect_uri` with redirect mode along with id_token and access_token in hash params.